### PR TITLE
Remove Android log level check

### DIFF
--- a/tolbaaken/src/main/java/com/q42/tolbaaken/Tolbaaken.kt
+++ b/tolbaaken/src/main/java/com/q42/tolbaaken/Tolbaaken.kt
@@ -68,9 +68,7 @@ interface TolbaakenLogger {
 object AndroidTolbaakenLogger : TolbaakenLogger {
     override fun log(level: TolbaakenLogLevel, tag: String, message: String, throwable: Throwable?) {
         val androidLogPriority = level.androidLogPriority
-        if (Log.isLoggable(tag, androidLogPriority)) {
-            Log.println(androidLogPriority, tag, formatMessage(message, throwable))
-        }
+        Log.println(androidLogPriority, tag, formatMessage(message, throwable))
     }
 
     private val TolbaakenLogLevel.androidLogPriority get() = when (this) {


### PR DESCRIPTION
Log level is done by enabling Tolbaaken only in Debug builds.
Log.isLoggable() requires to manually run adb commands on every test phone "setprop  log.tag.MyApp VERBOSE"

See https://mobiarch.wordpress.com/2012/05/11/proper-logging-from-android-application/
As reference, Timber does not use this Log.isLoggable() method neither: https://github.com/JakeWharton/timber/blob/master/timber/src/main/java/timber/log/Timber.java#L512

Without this fix all debug logs are not shown in logcat